### PR TITLE
fix:send only required fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1922,6 +1923,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2266,6 +2268,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -2949,6 +2952,7 @@
       "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3185,6 +3189,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",

--- a/src/routes/chatbot_questions.js
+++ b/src/routes/chatbot_questions.js
@@ -14,7 +14,6 @@ router.post("/question", async (req, res) => {
     if (!question || !qr_id) {
       return res.status(400).json({ error: "Los campos question y qr_id son obligatorios." });
     }
-
     const response = await axios.post(
       "https://www.chatbase.co/api/v1/chat",
       {

--- a/src/routes/page.js
+++ b/src/routes/page.js
@@ -4,7 +4,7 @@ const router = express.Router();
 
 // Obtener todas
 router.get('/', async (_req, res) => {
-    const { data, error } = await supabase.from('page').select('*');
+    const { data, error } = await supabase.from('page').select('id, name, content_markdown').order("name", { ascending: true });
     if (error) return res.status(400).json({ error: error.message });
     res.json({
         message: 'Listado obtenido correctamente.',
@@ -15,7 +15,7 @@ router.get('/', async (_req, res) => {
 // Obtener una por id
 router.get('/:id', async (req, res) => {
     const { id } = req.params; 
-    const { data, error } = await supabase.from('page').select('*').eq('id', id).single();
+    const { data, error } = await supabase.from('page').select('id, content_html').eq('id', id).single();
     if (error) return res.status(404).json({ error: error.message });
     res.json({
         message: `Page con id ${id} obtenida correctamente.`,


### PR DESCRIPTION
Optimized the backend response for pages by returning only the fields required by the frontend (id, name, content_markdown, content_html).
This reduces payload size and simplifies the editor logic.