### PR TITLE
Feat/testing user admin and staff

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -5,7 +5,7 @@ dotenv.config();
 
 export default defineConfig({
   expect: {
-    timeout: 15000
+    timeout: 20000
   },
   use: {
     baseURL: 'https://qr-g1-front.vercel.app/1', // acá pongo la url y con el /1 estoy en el qr 1 ya que no puedo escanear un qr en e2e

--- a/tests/e2e/qr-navegacion_usuario_admin.spec.js
+++ b/tests/e2e/qr-navegacion_usuario_admin.spec.js
@@ -33,7 +33,7 @@ test('test ir a instructivo del editor y ver el instructivo', async ({ page }) =
   await expect(page.locator('div').filter({ hasText: '📝 Instructivo Interactivo' }).nth(3)).toBeVisible();
 });
 
-test('test ir a listado de solicitudes y después pasarse al editor y más', async ({ page }) => {
+test('test ir a listado de solicitudes y después pasarse al editor y ', async ({ page }) => {
   await page.goto('https://qr-uc-christus.app/admin');
   await page.getByRole('textbox', { name: 'Email address' }).click();
   await page.getByRole('textbox', { name: 'Email address' }).fill(process.env.ADMIN_MAIL_LOGIN);

--- a/tests/e2e/qr-navegacion_usuario_admin.spec.js
+++ b/tests/e2e/qr-navegacion_usuario_admin.spec.js
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test';
+
+test('test entrar al panel y visualizar las distintas opciones', async ({ page }) => {
+  await page.goto('https://qr-uc-christus.app/admin');
+  await page.getByRole('textbox', { name: 'Email address' }).click();
+  await page
+    .getByRole("textbox", { name: "Email address" })
+    .fill(process.env.ADMIN_MAIL_LOGIN);
+  await page.getByRole('textbox', { name: 'Password' }).click();
+  await page
+    .getByRole("textbox", { name: "Password" })
+    .fill(process.env.ADMIN_PASSWORD_LOGIN);
+  await page.getByRole('button', { name: 'Continue' }).click();
+  await expect(page.locator('div').filter({ hasText: 'Editor de ContenidoPermite' }).nth(3)).toBeVisible();
+  await expect(page.locator('div').filter({ hasText: 'Instructivo del' }).nth(3)).toBeVisible();
+  await expect(page.locator('div').filter({ hasText: 'Listado de SolicitudesMuestra' }).nth(3)).toBeVisible();
+  await expect(page.locator('div').filter({ hasText: 'Dashboard de' }).nth(5)).toBeVisible();
+  await expect(page.locator('div').filter({ hasText: 'Dashboard de métricas' }).nth(5)).toBeVisible();
+  await expect(page.locator('div').filter({ hasText: 'Dashboard de métricas ChatbotReúne métricas e indicadores sobre el uso del' }).nth(3)).toBeVisible();
+});
+
+test('test ir a instructivo del editor y ver el instructivo', async ({ page }) => {
+  await page.goto('https://qr-uc-christus.app/admin');
+  await page.getByRole('textbox', { name: 'Email address' }).fill(process.env.ADMIN_MAIL_LOGIN);
+  await page.getByRole('textbox', { name: 'Email address' }).click({
+    modifiers: ['ControlOrMeta']
+  });
+  await page.getByRole('textbox', { name: 'Password' }).click();
+  await page.getByRole('textbox', { name: 'Password' }).fill(process.env.ADMIN_PASSWORD_LOGIN);
+  await page.getByRole('button', { name: 'Continue' }).click();
+  await page.getByRole('link', { name: 'Acceder arrow_right_alt' }).nth(1).click();
+  await expect(page.getByText('# 📝 **Instructivo')).toBeVisible();
+  await expect(page.locator('div').filter({ hasText: '📝 Instructivo Interactivo' }).nth(3)).toBeVisible();
+});
+
+test('test ir a listado de solicitudes y después pasarse al editor y más', async ({ page }) => {
+  await page.goto('https://qr-uc-christus.app/admin');
+  await page.getByRole('textbox', { name: 'Email address' }).click();
+  await page.getByRole('textbox', { name: 'Email address' }).fill(process.env.ADMIN_MAIL_LOGIN);
+  await page.getByText('Password *').click();
+  await page.getByRole('textbox', { name: 'Password' }).fill(process.env.ADMIN_PASSWORD_LOGIN);
+  await page.getByRole('button', { name: 'Continue' }).click();
+  await expect(page.locator('div').filter({ hasText: 'Listado de SolicitudesMuestra' }).nth(3)).toBeVisible();
+  await page.getByRole('link', { name: 'Acceder arrow_right_alt' }).nth(2).click();
+  await page.getByRole('button', { name: 'Siguiente →' }).click();
+  await page.getByRole('button', { name: 'Siguiente →' }).click();
+  await page.getByRole('button', { name: 'menu' }).click();
+  await page.getByRole('link', { name: 'Inicio' }).click();
+  await page.getByRole('button', { name: 'menu' }).click();
+  await page.getByRole('link', { name: 'Editor' }).click();
+  await page.getByRole('button', { name: 'menu' }).click();
+  await page.getByRole('link', { name: 'Inicio' }).click();
+});

--- a/tests/e2e/qr-navegacion_usuario_staff.spec.js
+++ b/tests/e2e/qr-navegacion_usuario_staff.spec.js
@@ -27,13 +27,11 @@ test('test ir al listado de solicitudes y visualizarlas', async ({ page }) => {
 });
 
 
-test('test ir al dashboard de metricas de solicitudes', async ({ page }) => {
+test('test hacer el log in y que se haga de forma correcta', async ({ page }) => {
   await page.goto('https://qr-uc-christus.app/admin');
   await page.getByRole('textbox', { name: 'Email address' }).click();
   await page.getByRole('textbox', { name: 'Email address' }).fill('dafne.valdivia@uc.cl');
   await page.getByRole('textbox', { name: 'Password' }).click();
   await page.getByRole('textbox', { name: 'Password' }).fill('20.819.320-1');
   await page.getByRole('button', { name: 'Continue' }).click();
-  await page.getByRole('link', { name: 'Acceder arrow_right_alt' }).nth(1).click();
-  await expect(page.locator('iframe[title="Google Looker Studio dashboard"]').contentFrame().getByText('Cantidad total de solicitudes realizadas. calendar_today Selecciona un periodo')).toBeVisible();
 });

--- a/tests/e2e/qr-navegacion_usuario_staff.spec.js
+++ b/tests/e2e/qr-navegacion_usuario_staff.spec.js
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+
+test('test entrar como staff y visualizar los paneles', async ({ page }) => {
+  await page.goto('https://qr-uc-christus.app/admin');
+  await page.getByRole('textbox', { name: 'Email address' }).click();
+  await page.getByRole('textbox', { name: 'Email address' }).fill('dafne.valdivia@uc.cl');
+  await page.getByRole('textbox', { name: 'Password' }).click();
+  await page.getByRole('textbox', { name: 'Password' }).fill('20.819.320-1');
+  await page.getByRole('button', { name: 'Continue' }).click();
+  await expect(page.locator('div').filter({ hasText: 'Listado de SolicitudesMuestra' }).nth(3)).toBeVisible();
+  await page.locator('div').filter({ hasText: 'Dashboard de' }).nth(3).click();
+});
+
+test('test ir al listado de solicitudes y visualizarlas', async ({ page }) => {
+  await page.goto('https://qr-uc-christus.app/admin');
+  await page.getByRole('textbox', { name: 'Email address' }).fill('dafne.valdivia@uc.cl');
+  await page.getByRole('textbox', { name: 'Email address' }).click({
+    modifiers: ['ControlOrMeta']
+  });
+  await page.getByRole('textbox', { name: 'Password' }).click();
+  await page.getByRole('textbox', { name: 'Password' }).fill('20.819.320-1');
+  await page.getByRole('button', { name: 'Continue' }).click();
+  await expect(page.locator('div').filter({ hasText: 'Listado de SolicitudesMuestra' }).nth(3)).toBeVisible();
+  await page.getByRole('link', { name: 'Acceder arrow_right_alt' }).first().click();
+  await expect(page.getByRole('heading', { name: 'Listado de solicitudes▶' })).toBeVisible();
+  await expect(page.locator('section')).toBeVisible();
+});
+
+
+test('test ir al dashboard de metricas de solicitudes', async ({ page }) => {
+  await page.goto('https://qr-uc-christus.app/admin');
+  await page.getByRole('textbox', { name: 'Email address' }).click();
+  await page.getByRole('textbox', { name: 'Email address' }).fill('dafne.valdivia@uc.cl');
+  await page.getByRole('textbox', { name: 'Password' }).click();
+  await page.getByRole('textbox', { name: 'Password' }).fill('20.819.320-1');
+  await page.getByRole('button', { name: 'Continue' }).click();
+  await page.getByRole('link', { name: 'Acceder arrow_right_alt' }).nth(1).click();
+  await expect(page.locator('iframe[title="Google Looker Studio dashboard"]').contentFrame().getByText('Cantidad total de solicitudes realizadas. calendar_today Selecciona un periodo')).toBeVisible();
+});


### PR DESCRIPTION
This pull request adds new end-to-end (E2E) Playwright test suites for both admin and staff user navigation in the QR UC Christus application. These tests automate the login process and verify that key dashboard features and navigation flows are working as expected for different user roles.

New E2E test coverage for admin users (`qr-navegacion_usuario_admin.spec.js`):

* Adds tests for admin login and checks visibility of key dashboard sections such as "Editor de Contenido", "Instructivo del Editor", "Listado de Solicitudes", and various dashboards.
* Verifies navigation to the instructive editor and checks for the presence of instructive content.
* Tests navigation from the list of requests to the editor, including menu interactions and returning to the home page.

New E2E test coverage for staff users (`qr-navegacion_usuario_staff.spec.js`):

* Adds tests for staff login and verifies access to panels such as the list of requests and dashboards.
* Tests navigation to the list of requests and checks for the correct display of request listings.
* Adds a test for accessing and verifying the metrics dashboard for requests, including visibility of metrics in an embedded Looker Studio iframe.